### PR TITLE
v1.0.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# CHANGELOG - envoy-proxy-demos
+
+## v2.0.0 (envoy api v2 based demo apps)
+
+WIP
+
+## v1.0.0 (envoy api v1 based demo apps)
+
+Supported & tested envoy versions:
+
+- [v1.12.3](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.12.3)
+- [v1.12.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.12.0)
+- [v1.9.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.9.0)
+- [v1.8.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.8.0)
+- [v1.7.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.7.0)
+- [v1.6.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.6.0)
+
+> NOTE: From envoy api [v1.13.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.13.0), v1 envoy api(s) are no longer supported.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,10 @@ This project is a fork of the [Envoy's example demo sets](https://github.com/env
 - [Jaeger Tracing](jaeger-tracing)
 - [Zipkin Tracing](zipkin-tracing)
 
+## Demo versions and supported envoy versions
+- v2.0.0 (WIP):  envoy api V2 based demo apps
+- v1.0.0: envoy api v1 based demo apps
+
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/yokawasa/envoy-proxy-demos

--- a/apps/Dockerfile-frontenvoy
+++ b/apps/Dockerfile-frontenvoy
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy:latest
+FROM envoyproxy/envoy:v1.12.3
 
 RUN apt-get update && apt-get -q install -y \
     curl

--- a/apps/Dockerfile-service
+++ b/apps/Dockerfile-service
@@ -1,4 +1,4 @@
-FROM envoyproxy/envoy-alpine:latest
+FROM envoyproxy/envoy-alpine:v1.12.3
 
 RUN apk update && apk add python3 bash
 RUN python3 --version && pip3 --version


### PR DESCRIPTION
## v1.0.0 (envoy api v1 based demo apps)

Supported & tested envoy versions:

- [v1.12.3](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.12.3)
- [v1.12.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.12.0)
- [v1.9.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.9.0)
- [v1.8.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.8.0)
- [v1.7.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.7.0)
- [v1.6.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.6.0)

> NOTE: From envoy api [v1.13.0](https://www.envoyproxy.io/docs/envoy/latest/version_history/v1.13.0), v1 envoy api(s) are no longer supported.
